### PR TITLE
allow incomplete session name in `dl` 

### DIFF
--- a/bnd/cli.py
+++ b/bnd/cli.py
@@ -152,6 +152,7 @@ def up(
     """
     Upload data to the server. If the file exists on the server, it won't be replaced.
     Every file in the session folder will get uploaded.
+    If animal name give, the last session will get uploaded.
 
     \b
     Example usage to upload everything of a given session:
@@ -185,8 +186,9 @@ def dl(
     ),
 ):
     """
-    Download experimental data from a given session from the remote server.
+    Download data of a given session from the remote server.
     If session exists locally, only missing files will be downloaded.
+    if session name is not complete (`M123_2025_02_03`), it will try to find a similar session.
 
     \b
     Example usage to download everything:

--- a/bnd/config.py
+++ b/bnd/config.py
@@ -69,6 +69,12 @@ class Config:
                 # Set as environment variable
                 setattr(self, key, Path(value))
 
+    def get_local_animal_path(self, animal_name_like: str) -> Path:
+        return self.LOCAL_PATH / "raw" / self.get_animal_name(animal_name_like)
+
+    def get_remote_animal_path(self, animal_name_like: str) -> Path:
+        return self.REMOTE_PATH / "raw" / self.get_animal_name(animal_name_like)
+
     def get_remote_session_path(self, session_name: str) -> Path:
         animal = self.get_animal_name(session_name)
         remote_session_path = self.REMOTE_PATH / "raw" / animal / session_name


### PR DESCRIPTION
`dl` will accept incomplete session name. Very useful to download data based on session date, without knowing the time, i.e., `bnd dl M056_2025_02_27`