### PR TITLE
Correct meta data

### DIFF
--- a/bnd/config.py
+++ b/bnd/config.py
@@ -149,30 +149,29 @@ def _load_config() -> Config:
     return Config()
 
 
-def find_file(
-    main_path: str | Path, extension: tuple[str | Path] = (".txt",)
-) -> list[Path]:
+def find_file(path: str | Path, extension: tuple[str] = ('.raw.kwd',)) -> list[Path]:
     """
-    This function finds all the file types specified by 'extension' in the 'main_path' directory
-    and all its subdirectories and their sub-subdirectories etc.,
-    and returns a list of all file paths
-    'extension' is a list of desired file extensions: ['.dat','.prm']
+    Recursively finds files with the specified extensions within the given path.
+    `path` (str or Path): The directory in which to search for files.
+    `extension`: A tuple of file extensions e.g., ('.dat', '.prm').
     """
-    if isinstance(main_path, str):
-        path = Path(main_path)
-    else:
-        path = main_path
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Path does not exist: {p}")
 
+    # Convert extension to list if it is a string.
     if isinstance(extension, str):
-        extension = extension.split()  # turning extension into a list with a single element
+        extension = extension.split()
 
-    return [
-        Path(walking[0] / goodfile)
-        for walking in path.walk()
-        for goodfile in walking[2]
-        for ext in extension
-        if goodfile.endswith(ext)
-    ]
+    # Normalize extensions to ensure they start with a dot.
+    normalized_exts = [ext if ext.startswith('.') else '.' + ext for ext in extension]
+
+    found_files = []
+    for ext in normalized_exts:
+        for file in p.rglob(f"*{ext}"):
+            if file.is_file():
+                found_files.append(file)
+    return found_files
 
 
 def list_dirs(main_path: str | Path) -> list[str]:

--- a/bnd/pipeline/kilosort.py
+++ b/bnd/pipeline/kilosort.py
@@ -45,7 +45,7 @@ def add_entry_to_metadata(filepath: Path, tag: str, value: str) -> None:
     # Write back without the dummy section
     with open(filepath, 'w') as f:
         for key, val in config.items('dummy_section'):
-            f.write(f"{key} = {val}\n")
+            f.write(f"{key}={val}\n")
 
 def _read_probe_type(meta_file_path: str) -> str:
     meta = read_metadata(meta_file_path)

--- a/bnd/pipeline/kilosort.py
+++ b/bnd/pipeline/kilosort.py
@@ -31,21 +31,8 @@ def add_entry_to_metadata(filepath: Path, tag: str, value: str) -> None:
     """
     Add or update a tag=value entry in the NPx metadata.
     """
-    # Read and inject dummy section
-    with open(filepath, 'r') as f:
-        content = f.read()
-    content_with_section = '[dummy_section]\n' + content
-
-    # Parse and modify
-    config = ConfigParser()
-    config.optionxform = str  # disables lowercasing
-    config.read_string(content_with_section)
-    config.set('dummy_section', tag, value)
-
-    # Write back without the dummy section
-    with open(filepath, 'w') as f:
-        for key, val in config.items('dummy_section'):
-            f.write(f"{key}={val}\n")
+    with open(filepath, 'a') as f:  # append mode
+        f.write(f"{tag}={value}\n")
 
 def _read_probe_type(meta_file_path: str) -> str:
     meta = read_metadata(meta_file_path)

--- a/bnd/pipeline/kilosort.py
+++ b/bnd/pipeline/kilosort.py
@@ -21,6 +21,7 @@ def read_metadata(filepath: Path) -> dict:
         content_with_section = '[dummy_section]\n' + content
 
     config = ConfigParser()
+    config.optionxform = str  # disables lowercasing
     config.read_string(content_with_section)
 
     return dict(config.items('dummy_section'))
@@ -37,6 +38,7 @@ def add_entry_to_metadata(filepath: Path, tag: str, value: str) -> None:
 
     # Parse and modify
     config = ConfigParser()
+    config.optionxform = str  # disables lowercasing
     config.read_string(content_with_section)
     config.set('dummy_section', tag, value)
 


### PR DESCRIPTION
add missing values to the local copy of the metadata file to allow smooth kilosort and pyaldata conversion